### PR TITLE
Fix/background styles

### DIFF
--- a/src/SavedView/SavedView.scss
+++ b/src/SavedView/SavedView.scss
@@ -17,6 +17,7 @@
 
 .saved-thumbnail-container {
   @include row-wrap-around;
+  background: url('./background.png') repeat fixed;
 }
 
 @media only screen and (max-width: 1025px) {


### PR DESCRIPTION
## What's this PR do?
- Fixes the problem of the blue bg not extending to the bottom of the container of the `Saved View` by adding saved-view bg to saved-thumbnail-container

## Where should the reviewer start?
- `SavedView.scss`

## How should this be manually tested?
- test in browser by looking at saved view... blue should extend to bottom no matter how many trips are added

## Any background context you want to provide?
- n/a

## What are the relevant tickets?
- n/a

## Screenshots/GIFs
- n/a

## Questions:
- n/a

## Did you update the README?
- n/a
